### PR TITLE
Adding support for strings-rules. Extending IDA plugin functionality

### DIFF
--- a/mkyara/gen.py
+++ b/mkyara/gen.py
@@ -27,25 +27,24 @@ log = logging.getLogger(__package__)
 
 
 class DataChunk(object):
-    def __init__(self, data, offset=0, is_data=False):
+    def __init__(self, data, sig_mode, offset=0, is_data=False):
         self.data = data
         self.offset = offset
+        self.sig_mode = sig_mode
         self.is_data = is_data
 
 
 class YaraGenerator(object):
-    def __init__(self, sig_mode, instruction_set, instruction_mode, rule_name="generated_rule", do_comment=True):
+    def __init__(self, instruction_set, instruction_mode, rule_name="generated_rule", do_comment=True):
         self.instruction_set = instruction_set
         self.instruction_mode = instruction_mode
         self.do_comment_sig = do_comment
-        self.sig_mode = sig_mode
-        self.rule_name = rule_name
-        self.yr_rule = YaraRule()
+        self.rule_name = rule_name        
         self._signature = ""
         self._chunks = []
 
-    def add_chunk(self, data, offset=0, is_data=False):
-        self._chunks.append(DataChunk(data, offset=offset, is_data=is_data))
+    def add_chunk(self, data, sig_mode, offset=0, is_data=False):
+        self._chunks.append(DataChunk(data, sig_mode, offset=offset, is_data=is_data))
 
     def _hex_opcode(self, opcode_list):
         """ Returns a HEX string representation of the Capstone opcode list """
@@ -64,7 +63,7 @@ class YaraGenerator(object):
             data[i] = "?"
         return data
 
-    def _process_instruction(self, ins):
+    def _process_instruction(self, ins, sig_mode):
         """ Process an instruction of the binary, generating a pattern/signature for it """
         ins_str = "{} {}".format(ins.mnemonic, ins.op_str)
         opcode_hex_str = self._hex_opcode(ins.opcode)
@@ -87,9 +86,9 @@ class YaraGenerator(object):
 
         ins_hex_list = list(ins_hex)
 
-        if self.should_wildcard_imm_operand(ins):
+        if self.should_wildcard_imm_operand(ins, sig_mode):
             ins_hex_list = self._wilcard_bytes(ins_hex_list, ins.imm_offset * 2, ins.imm_size * 2)
-        if self.should_wildcard_disp_operand(ins):
+        if self.should_wildcard_disp_operand(ins, sig_mode):
             ins_hex_list = self._wilcard_bytes(ins_hex_list, ins.disp_offset * 2, ins.disp_size * 2)
 
         signature = ''.join(ins_hex_list)
@@ -102,14 +101,14 @@ class YaraGenerator(object):
                 return True
         return False
 
-    def should_wildcard_disp_operand(self, ins):
-        if self.sig_mode in ["loose", "normal"]:
+    def should_wildcard_disp_operand(self, ins, sig_mode):
+        if sig_mode in ["loose", "normal"]:
             return True
         else:
             return self.is_jmp_or_call(ins)
 
-    def should_wildcard_imm_operand(self, ins):
-        if self.sig_mode in ["loose"]:
+    def should_wildcard_imm_operand(self, ins, sig_mode):
+        if sig_mode in ["loose"]:
             return True
         else:
             return self.is_jmp_or_call(ins)
@@ -120,10 +119,11 @@ class YaraGenerator(object):
 
     def generate_rule(self):
         """ Generate Yara rule. Return a YaraRule object """
-        self.yr_rule.rule_name = self.rule_name
-        self.yr_rule.metas["generated_by"] = "\"mkYARA - By Jelle Vergeer\""
-        self.yr_rule.metas["date"] = "\"{}\"".format(datetime.now().strftime("%Y-%m-%d %H:%M"))
-        self.yr_rule.metas["version"] = "\"1.0\""
+        yr_rule = YaraRule()
+        yr_rule.rule_name = self.rule_name
+        yr_rule.metas["generated_by"] = "\"mkYARA - By Jelle Vergeer\""
+        yr_rule.metas["date"] = "\"{}\"".format(datetime.now().strftime("%Y-%m-%d %H:%M"))
+        yr_rule.metas["version"] = "\"1.0\""
 
         md = Cs(self.instruction_set, self.instruction_mode)
         md.detail = True
@@ -135,19 +135,22 @@ class YaraGenerator(object):
             chunk_id = "$chunk_{}".format(chunk_nr)
             chunk_signature = ""
             chunk_comment = ""
-            if chunk.is_data is False:
+            if chunk.sig_mode == "string":
+                chunk_signature = repr(chunk.data)[1:-1]
+                yr_rule.add_string(chunk_id, chunk_signature, StringType.STRING)
+            elif chunk.is_data is False:
                 disasm = md.disasm(chunk.data, chunk.offset)
                 for ins in disasm:
-                    rule_part, comment = self._process_instruction(ins)
+                    rule_part, comment = self._process_instruction(ins, chunk.sig_mode)
                     rule_part = self.format_hex(rule_part)
                     chunk_signature += rule_part + "\n"
                     chunk_comment += comment + "\n"
-                self.yr_rule.add_string(chunk_id, chunk_signature, StringType.HEX)
+                yr_rule.add_string(chunk_id, chunk_signature, StringType.HEX)
                 if self.do_comment_sig:
-                    self.yr_rule.comments.append(chunk_comment)
+                    yr_rule.comments.append(chunk_comment)
             else:
                 rule_part = self.format_hex(chunk.data.encode("hex"))
-                self.yr_rule.add_string(chunk_id, rule_part, StringType.HEX)
+                yr_rule.add_string(chunk_id, rule_part, StringType.HEX)
 
-        self.yr_rule.condition = "any of them"
-        return self.yr_rule
+        yr_rule.condition = "any of them"
+        return yr_rule

--- a/mkyara/ida/mkyara_plugin.py
+++ b/mkyara/ida/mkyara_plugin.py
@@ -60,12 +60,10 @@ def get_arch_info():
 
 
 class YaraRuleDialog(QtWidgets.QDialog):
-    def __init__(self, parent, start_addr, end_addr, yara_rule):
+    def __init__(self, parent, clear_btn_clicked):
         super(YaraRuleDialog, self).__init__(parent)
-        self.start_addr = start_addr
-        self.end_addr = end_addr
-        self.yara_rule = yara_rule
-        self.populate_form()
+        self.clear_btn_clicked = clear_btn_clicked
+        self.populate_form()        
 
     def populate_form(self):
         self.setWindowTitle('mkYARA :: Generated Yara Rule')
@@ -76,7 +74,7 @@ class YaraRuleDialog(QtWidgets.QDialog):
         self.bottom_layout.setAlignment(Qt.AlignRight | Qt.AlignBottom)
         # layout.addStretch()
 
-        self.layout.addWidget(QtWidgets.QLabel("Generated Yara rule from 0x{:x} to 0x{:x}".format(self.start_addr, self.end_addr)))
+        self.layout.addWidget(QtWidgets.QLabel("Generated Yara rule"))
         self.text_edit = QtWidgets.QTextEdit()
         font = QtGui.QFont()
         font.setFamily("Consolas")
@@ -87,8 +85,13 @@ class YaraRuleDialog(QtWidgets.QDialog):
         metrics = QtGui.QFontMetrics(font)
         self.text_edit.setTabStopWidth(4 * metrics.width(' '))
 
-        self.text_edit.insertPlainText(self.yara_rule)
         self.layout.addWidget(self.text_edit)
+
+        self.clear_btn = QtWidgets.QPushButton("Clear")
+        self.clear_btn.setFixedWidth(100)
+        self.clear_btn.clicked.connect(self.clear_btn_clicked)
+        self.clear_btn.clicked.connect(self.clear_btn_clicked_internal)
+        self.bottom_layout.addWidget(self.clear_btn)
 
         self.ok_btn = QtWidgets.QPushButton("OK")
         self.ok_btn.setFixedWidth(100)
@@ -101,6 +104,9 @@ class YaraRuleDialog(QtWidgets.QDialog):
     def ok_btn_clicked(self):
         self.close()
 
+    def clear_btn_clicked_internal(self):
+        self.text_edit.clear()
+
 
 class mkYARAPlugin(idaapi.plugin_t):
     flags = idaapi.PLUGIN_FIX
@@ -109,41 +115,60 @@ class mkYARAPlugin(idaapi.plugin_t):
     wanted_name = "mkYARA"
     wanted_hotkey = ""
     dialog = None
+    yr_gen = None
 
     def init(self):
         loose_yara_action = idaapi.action_desc_t(
-            'mkYARA:generate_loose_yara',   # The action name. This acts like an ID and must be unique
-            'Generate Loose Yara Rule ',  # The action text.
+            'mkYARA:add_loose_yara',   # The action name. This acts like an ID and must be unique
+            'Add Loose Yara Rule ',  # The action text.
             generic_handler(lambda: self.generate_yara_rule("loose")),   # The action handler.
             None,      # Optional: the action shortcut
-            'Generate loose yara rule',  # Optional: the action tooltip (available in menus/toolbar)
+            'Add loose yara rule',  # Optional: the action tooltip (available in menus/toolbar)
             199  # Optional: the action icon (shows when in menus/toolbars)
         )
 
         normal_yara_action = idaapi.action_desc_t(
-            'mkYARA:generate_normal_yara',   # The action name. This acts like an ID and must be unique
-            'Generate Normal Yara Rule ',  # The action text.
+            'mkYARA:add_normal_yara',   # The action name. This acts like an ID and must be unique
+            'Add Normal Yara Rule ',  # The action text.
             generic_handler(lambda: self.generate_yara_rule("normal")),   # The action handler.
             'Ctrl+Y',      # Optional: the action shortcut
-            'Generate normal yara rule',  # Optional: the action tooltip (available in menus/toolbar)
+            'Add normal yara rule',  # Optional: the action tooltip (available in menus/toolbar)
             199  # Optional: the action icon (shows when in menus/toolbars)
         )
 
         strict_yara_action = idaapi.action_desc_t(
-            'mkYARA:generate_strict_yara',   # The action name. This acts like an ID and must be unique
-            'Generate Strict Yara Rule ',  # The action text.
+            'mkYARA:add_strict_yara',   # The action name. This acts like an ID and must be unique
+            'Add Strict Yara Rule ',  # The action text.
             generic_handler(lambda: self.generate_yara_rule("strict")),   # The action handler.
             None,      # Optional: the action shortcut
-            'Generate strict yara rule',  # Optional: the action tooltip (available in menus/toolbar)
+            'Add strict yara rule',  # Optional: the action tooltip (available in menus/toolbar)
             199  # Optional: the action icon (shows when in menus/toolbars)
         )
 
         data_yara_action = idaapi.action_desc_t(
-            'mkYARA:generate_data_yara',   # The action name. This acts like an ID and must be unique
-            'Generate Data Yara Rule ',  # The action text.
+            'mkYARA:add_data_yara',   # The action name. This acts like an ID and must be unique
+            'Add Data Yara Rule ',  # The action text.
             generic_handler(lambda: self.generate_yara_rule("normal", is_data=True)),   # The action handler.
             None,      # Optional: the action shortcut
-            'Generate data yara rule',  # Optional: the action tooltip (available in menus/toolbar)
+            'Add data yara rule',  # Optional: the action tooltip (available in menus/toolbar)
+            199  # Optional: the action icon (shows when in menus/toolbars)
+        )
+
+        string_yara_action = idaapi.action_desc_t(
+            'mkYARA:add_string_yara',   # The action name. This acts like an ID and must be unique
+            'Add String Yara Rule ',  # The action text.
+            generic_handler(lambda: self.generate_yara_rule("string")),   # The action handler.
+            'Ctrl+N',      # Optional: the action shortcut
+            'Add string yara rule',  # Optional: the action tooltip (available in menus/toolbar)
+            199  # Optional: the action icon (shows when in menus/toolbars)
+        )
+
+        generate_yara_action = idaapi.action_desc_t(
+            'mkYARA:generate_yara_rule',   # The action name. This acts like an ID and must be unique
+            'Generate Yara Rule ',  # The action text.
+            generic_handler(lambda: self.generate_yara_rule("generate")),   # The action handler.
+            'Ctrl+Shift+Y',      # Optional: the action shortcut
+            'Generate yara rule',  # Optional: the action tooltip (available in menus/toolbar)
             199  # Optional: the action icon (shows when in menus/toolbars)
         )
 
@@ -151,24 +176,40 @@ class mkYARAPlugin(idaapi.plugin_t):
         idaapi.register_action(normal_yara_action)
         idaapi.register_action(strict_yara_action)
         idaapi.register_action(data_yara_action)
+        idaapi.register_action(string_yara_action)
+        idaapi.register_action(generate_yara_action)
         self.ui_hooks = mkYARAUIHooks()
         self.ui_hooks.hook()
         print('mkYARA :: Plugin Started')
         return idaapi.PLUGIN_KEEP
 
-    def generate_yara_rule(self, mode, is_data=False):
-        start, end = get_selection()
-        size = end - start
-        data = idaapi.get_many_bytes(start, size)
-        ins_set, ins_mode = get_arch_info()
-        yr_gen = YaraGenerator(mode, ins_set, ins_mode)
-        yr_gen.add_chunk(data, offset=start, is_data=is_data)
-        rule_obj = yr_gen.generate_rule()
-        file_hash = get_input_file_hash()
-        rule_obj.metas["hash"] = "\"{}\"".format(file_hash)
-        rule = rule_obj.get_rule_string()
-        self.dialog = YaraRuleDialog(None, start, end, rule)
-        self.dialog.show()
+    def clear_yara(self):
+        self.yr_gen = None
+
+    def generate_yara_rule(self, mode, is_data=False):        
+        if self.yr_gen == None:
+            ins_set, ins_mode = get_arch_info()
+            self.yr_gen = YaraGenerator(ins_set, ins_mode)
+        
+        if mode == 'generate':
+            if self.dialog == None:
+                self.dialog = YaraRuleDialog(None, self.clear_yara)
+            self.dialog.show()
+        else:
+            start, end = get_selection()
+            size = end - start
+            data = idaapi.get_many_bytes(start, size)
+            self.yr_gen.add_chunk(data, mode, offset=start, is_data=is_data)
+            print("Added pattern of type {}: {}  ".format(mode, repr(data[1:-1])))
+
+        if self.dialog != None:
+            rule_obj = self.yr_gen.generate_rule()
+            file_hash = get_input_file_hash()
+            rule_obj.metas["hash"] = "\"{}\"".format(file_hash)
+            rule = rule_obj.get_rule_string()
+            self.dialog.text_edit.clear()
+            self.dialog.text_edit.insertPlainText(rule)    
+
 
     def term(self):
         self.ui_hooks.unhook()
@@ -196,10 +237,13 @@ class mkYARAUIHooks(idaapi.UI_Hooks):
         pass
 
     def finish_populating_tform_popup(self, form, popup):
-        idaapi.attach_action_to_popup(form, popup, "mkYARA:generate_loose_yara", "mkYARA/")
-        idaapi.attach_action_to_popup(form, popup, "mkYARA:generate_normal_yara", "mkYARA/")
-        idaapi.attach_action_to_popup(form, popup, "mkYARA:generate_strict_yara", "mkYARA/")
-        idaapi.attach_action_to_popup(form, popup, "mkYARA:generate_data_yara", "mkYARA/")
+        idaapi.attach_action_to_popup(form, popup, "mkYARA:add_loose_yara", "mkYARA/")
+        idaapi.attach_action_to_popup(form, popup, "mkYARA:add_normal_yara", "mkYARA/")
+        idaapi.attach_action_to_popup(form, popup, "mkYARA:add_strict_yara", "mkYARA/")
+        idaapi.attach_action_to_popup(form, popup, "mkYARA:add_data_yara", "mkYARA/")
+        idaapi.attach_action_to_popup(form, popup, "mkYARA:add_string_yara", "mkYARA/")
+        idaapi.attach_action_to_popup(form, popup, "mkYARA:generate_yara_rule", "mkYARA/")
+        
 
 
 plugin = mkYARAPlugin()

--- a/mkyara/utils/mkyara_tool.py
+++ b/mkyara/utils/mkyara_tool.py
@@ -54,7 +54,7 @@ def main():
     parser.add_argument('-n', '--rulename', type=str, help='Generated rule name', default="generated_rule")
     parser.add_argument('-o', '--offset', type=auto_int, help='File offset for signature', required=True)
     parser.add_argument('-s', '--size', type=auto_int, help='Size of desired signature', required=True)
-    parser.add_argument('-m', '--mode', type=str, help="""Wildcard mode for yara rule generation\nloose = wildcard all operands\nnormal = wildcard only displacement operands\nstrict = wildcard only jmp/call addresses""", required=False, choices=["loose", "normal", "strict"], default="normal")
+    parser.add_argument('-m', '--mode', type=str, help="""Wildcard mode for yara rule generation\nloose = wildcard all operands\nnormal = wildcard only displacement operands\nstrict = wildcard only jmp/call addresses""", required=False, choices=["loose", "normal", "strict", "string"], default="normal")
     parser.add_argument('-r', '--result', type=argparse.FileType('w'), help='Output file', required=False, default=None)
     parser.add_argument("-v", "--verbose", action="count", default=0, help="Increase verbosity")
     args = parser.parse_args()
@@ -66,11 +66,11 @@ def main():
     log.info("Disassembling code and generating signature...")
     ins_set = INSTRUCTION_SET_MAPPING[args.instruction_set]
     ins_mode = INSTRUCTION_MODE_MAPPING[args.instruction_mode]
-    yr_gen = YaraGenerator(args.mode, ins_set, ins_mode, rule_name=args.rulename)
+    yr_gen = YaraGenerator(ins_set, ins_mode, rule_name=args.rulename)
     with open(args.file_path, 'rb') as file:
         file.seek(args.offset)
         data = file.read(args.size)
-        yr_gen.add_chunk(data, args.offset)
+        yr_gen.add_chunk(data, args.mode, args.offset)
 
     yr_rule = yr_gen.generate_rule()
     yr_rule.metas["sample"] = "\"{}\"".format(sha256_hash(args.file_path))


### PR DESCRIPTION
In this Pull Request I:
- Added support for strings in rules
- Extended the IDA plugin by a "String Yara Rule" option
- Added a "clear" button to the IDA plugin windows
- Added support for multiple patterns in one rule for the IDA plugin

Sorry for some larger refactoring. But it was necessary in order to introduce the new features.
The support for multiple patterns now also changes the behavior of the IDA plugin a bit, I hope that is ok for you. :)