### PR TITLE
Fix issues with Python3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+*pyc
+
+*egg-info

--- a/mkyara/gen.py
+++ b/mkyara/gen.py
@@ -1,7 +1,6 @@
 import binascii
 import codecs
 import logging
-import sys
 from capstone import (
     Cs,
     CS_OPT_SYNTAX_INTEL,
@@ -152,13 +151,15 @@ class YaraGenerator(object):
                         chunk_id,
                         chunk_signature,
                         StringType.HEX)
+
                 if self.do_comment_sig:
                     self.yr_rule.comments.append(chunk_comment)
             else:
-                if sys.version_info < (3, 0):
-                    rule_part = self.format_hex(chunk.data.encode("hex"))
-                else:
-                    rule_part = self.format_hex(chunk.data.hex())
+                rule_part = self.format_hex(
+                        "{}".format(
+                            binascii.hexlify(chunk.data).decode()
+                            )
+                        )
 
                 self.yr_rule.add_string(chunk_id, rule_part, StringType.HEX)
 


### PR DESCRIPTION
Fix issue described in https://github.com/fox-it/mkYARA/issues/6#issue-1019668718

Rewrote coding data bytes to hex by binascii.hexlify(). Intended to make python2-3 compatible code without python version checks.

Fix ida plugin getting md5 file string. In python3 with ida 7.2+ GetInputFileMD5 returns bytes instead of string. Add checks for rtype.

Must be working on all python version (2.7+, 3.5+).

