### PR TITLE
added version check and patch for ida9.0

### DIFF
--- a/mkyara/ida/mkyara_plugin.py
+++ b/mkyara/ida/mkyara_plugin.py
@@ -15,6 +15,10 @@ from capstone import (
 from PyQt5 import QtGui, QtWidgets
 from PyQt5.QtCore import Qt
 
+major, minor = map(int, idaapi.get_kernel_version().split("."))
+
+IDA_9 = major >= 9
+
 INSTRUCTION_SET_MAPPING = {
     'metapc': CS_ARCH_X86,
 }
@@ -34,19 +38,15 @@ def get_selection():
     return start, end
 
 
-def get_inf_structure_bitness(info):
-    bits = 16
-    if info.is_64bit():
-        bits = 64
-    elif info.is_32bit():
-        bits = 32
-    return bits
-
 
 def get_arch_info():
-    info = idaapi.get_inf_structure()
-    proc = info.procName.lower()
-    bits = get_inf_structure_bitness(info)
+    if IDA_9:
+        proc = idaapi.inf_get_procname().lower()
+        bits = 32 if idaapi.inf_is_32bit_exactly() else 64 if idaapi.inf_is_64bit() else 16 
+    else:
+        info = idaapi.get_inf_structure()
+        proc = info.procName.lower()
+        bits = 32 if info.is_32bit() else 64 if info.is_64bit() else 16
     instruction_set = None
     instruction_mode = None
 

--- a/mkyara/ida/mkyara_plugin.py
+++ b/mkyara/ida/mkyara_plugin.py
@@ -15,9 +15,7 @@ from capstone import (
 from PyQt5 import QtGui, QtWidgets
 from PyQt5.QtCore import Qt
 
-major, minor = map(int, idaapi.get_kernel_version().split("."))
-
-IDA_9 = major >= 9
+major, minor = [int(v) for v in idaapi.get_kernel_version().split('.')]
 
 INSTRUCTION_SET_MAPPING = {
     'metapc': CS_ARCH_X86,
@@ -37,12 +35,17 @@ def get_selection():
         end = idaapi.get_item_end(ea)
     return start, end
 
-
-
 def get_arch_info():
-    if IDA_9:
+    if major >= 9:
         proc = idaapi.inf_get_procname().lower()
-        bits = 32 if idaapi.inf_is_32bit_exactly() else 64 if idaapi.inf_is_64bit() else 16 
+        if idaapi.inf_is_64bit():
+            bits = 64
+        elif idaapi.inf_is_32bit_exactly():
+            bits = 32
+        elif idaapi.inf_is_16bit():
+            bits = 16
+        else:
+            raise ValueError
     else:
         info = idaapi.get_inf_structure()
         proc = info.procName.lower()


### PR DESCRIPTION
idaapi.get_inf_structure() is removed from ida9.0

> ## ida_idaapi
> ### Removed functions
>
> - get_inf_structure see inf_structure getters and inf_structure setters

> ### inf_structure accessors
> 
> As will be shown in ida_idaapi Removed functions get_inf_structure has been removed. It has been replaced by the following accessors.
> **Replacement examples:**
> 
> | In 8.4                                    | In 9.0                         |
> | ----------------------------------------- | ------------------------------ |
> | ida_idaapi.get_inf_structure().procname   | ida_ida.inf_get_procname()     |
> | ida_idaapi.get_inf_structure().max_ea     | ida_ida.inf_get_max_ea()       |
> | ida_idaapi.get_inf_structure().is_32bit() | ida_ida.inf_is_32bit_exactly() |

Source: https://docs.hex-rays.com/developer-guide/idapython/idapython-porting-guide-ida-9#ida_idaapi

to address this i've added a version check, if installed on ida9 it uses the new functions, otherwise it continues using `idaapi,get_inf_structure()`